### PR TITLE
Build and publish container images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 data
-!data/fonts
 cache
 build/layer

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 data
+!data/fonts
 cache
 build/layer

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+data
+cache
+build/layer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
 
+      - name: Download Fonts
+        run: bin/download-fonts
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v4
+        with:
+          name: mbtiles
+          path: build
 
       - name: Download Fonts
         run: bin/download-fonts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,22 @@
-name: Publish Dataset
+name: Publish
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - "*"
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -36,3 +45,62 @@ jobs:
         with:
           name: mbtiles
           path: "build/*.mbtiles"
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # https://docs.docker.com/build/ci/github-actions/multi-platform/
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=edge,branch=main
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /data/
 /cache/
 /build/
+styles/fonts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM maptiler/tileserver-gl:latest
+
+COPY . .
+
+CMD [ "--port", "${PORT:-8080}" "--config", "config.json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM maptiler/tileserver-gl:latest
 
 COPY . .
 
-CMD [ "--port", "${PORT:-8080}" "--config", "config.json" ]
+CMD [ "--config", "config.json" ]

--- a/bin/download-fonts
+++ b/bin/download-fonts
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$0")/.."
+mkdir -p data
+
+if ! [ -f data/noto-sans.zip ]; then
+  echo "Downloading fonts"
+  curl -sSfL -C - -o data/noto-sans.zip https://github.com/openmaptiles/fonts/releases/download/v2.0/noto-sans.zip
+fi
+
+if ! [ -d styles/fonts ]; then
+  echo "Extracting fonts"
+  mkdir -p styles/fonts
+  unzip -o data/noto-sans.zip -d styles/fonts
+fi

--- a/bin/normalize-ne
+++ b/bin/normalize-ne
@@ -5,6 +5,8 @@
 # - Set tippecanoe minzoom based on min_zoom or scalerank.
 # - Convert all property keys to lowercase.
 
+set -o errexit
+
 jq '
   . | .features |= map(
       del(..|nulls) |

--- a/bin/ogr2ogr
+++ b/bin/ogr2ogr
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 bin/run gdal ogr2ogr "$@"

--- a/bin/run
+++ b/bin/run
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 # Check if both stdin and stdout are a TTY
 if [ -t 0 ] && [ -t 1 ]; then
   TTY_FLAGS="-it"

--- a/bin/tile-join
+++ b/bin/tile-join
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
+set -o errexit
+
 bin/run tippecanoe tile-join "$@"

--- a/bin/tippecanoe
+++ b/bin/tippecanoe
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
 
-bin/run tippecanoe tippecanoe "$@"
+set -o errexit
+
+# If stdout is not a TTY, throttle progress updates
+if [ -t 1 ]; then
+  PROGRESS_OPTION=""
+else
+  PROGRESS_OPTION="--progress-interval=10"
+fi
+
+bin/run tippecanoe tippecanoe $PROGRESS_OPTION "$@"

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "options": {
     "paths": {
-      "fonts": "data/fonts",
+      "fonts": "styles/fonts",
       "styles": "styles",
       "mbtiles": "build"
     }


### PR DESCRIPTION
After building the charts, this will publish a docker container that can be used to run the tileserver and serve these charts.

For now this just bundles the generated charts into the image. Eventually this should probably just be the tileserver that fetches charts from releases, but this was the quickest/easiest way to get started.